### PR TITLE
feat(voice-coach): add task tracking and auto-end indication

### DIFF
--- a/app/api/voice-coach/history/route.ts
+++ b/app/api/voice-coach/history/route.ts
@@ -6,6 +6,7 @@ interface SessionRow {
   id: string;
   mode: string | null;
   summary: string | null;
+  action_points: { task: string | null }[] | null;
   transcript: string | null;
   created_at: string | null;
   duration_seconds: number | null;
@@ -16,6 +17,7 @@ interface VoiceCoachHistoryItem {
   title: string;
   mode: string;
   summary: string | null;
+  task: string | null;
   transcript: string;
   createdAt: string | null;
   durationSeconds: number | null;
@@ -46,11 +48,13 @@ function buildSessionTitle(session: SessionRow): string {
 }
 
 function mapHistoryItem(session: SessionRow): VoiceCoachHistoryItem {
+  const latestTask = session.action_points?.[0]?.task?.trim() ?? null;
   return {
     id: session.id,
     title: buildSessionTitle(session),
     mode: session.mode?.trim() || "Voice Coach",
     summary: session.summary,
+    task: latestTask || null,
     transcript: session.transcript?.trim() ?? "",
     createdAt: session.created_at,
     durationSeconds: session.duration_seconds,
@@ -75,7 +79,7 @@ export async function GET(request: NextRequest) {
     const { data, error } = await supabase
       .from("sessions")
       .select(
-        "id, mode, summary, transcript, created_at, duration_seconds, feature, user_name",
+        "id, mode, summary, transcript, created_at, duration_seconds, feature, user_name, action_points(task, created_at)",
       )
       .eq("user_name", userName)
       .eq("feature", "voice_coach")

--- a/app/api/voice-coach/signed-url/route.ts
+++ b/app/api/voice-coach/signed-url/route.ts
@@ -13,6 +13,36 @@ import {
   getPublicAgentFallbackWarning,
 } from "@/lib/elevenlabs-errors";
 
+const FALLBACK_MEMORY = `Previous Session Summary:
+- First session with Podium AI
+
+Weaknesses:
+- (not yet assessed)
+
+Strengths:
+- (not yet assessed)
+
+Current Goal:
+Build communication confidence through regular practice`;
+
+async function getMemoryWithTimeout(
+  userName: string,
+  mode: Parameters<typeof buildCoachMemory>[1],
+  timeoutMs = 3500,
+): Promise<string> {
+  try {
+    return await Promise.race<string>([
+      buildCoachMemory(userName, mode),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve(FALLBACK_MEMORY), timeoutMs);
+      }),
+    ]);
+  } catch (error) {
+    console.error("[voice-coach/signed-url] memory build failed:", error);
+    return FALLBACK_MEMORY;
+  }
+}
+
 export async function GET(request: NextRequest) {
   try {
     const mode = request.nextUrl.searchParams.get("mode");
@@ -39,13 +69,14 @@ export async function GET(request: NextRequest) {
 
     const apiKey = getElevenLabsApiKey()!;
     const agentId = getElevenLabsAgentId()!;
-    const memory = await buildCoachMemory(userName, mode);
-
-    const signed = await fetchElevenLabsSignedUrl(agentId, apiKey);
+    const [memory, signed] = await Promise.all([
+      getMemoryWithTimeout(userName, mode),
+      fetchElevenLabsSignedUrl(agentId, apiKey),
+    ]);
 
     if (!signed.ok) {
       console.error(
-        "[voice-coach/signed-url] ElevenLabs error:",
+        "[voice-coach/signed-url] ElevenLabs signed-url error:",
         signed.status,
         signed.detail,
       );
@@ -70,7 +101,8 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({
       authMode: "signed",
-      signedUrl: signed.signedUrl,
+      signedUrl: signed.value,
+      agentId,
       memory,
       mode,
     });

--- a/components/voice-coach/voice-coach-page.tsx
+++ b/components/voice-coach/voice-coach-page.tsx
@@ -62,10 +62,16 @@ export function VoiceCoachPage() {
   const showGuestBanner = isAnonymousVoiceCoachUser(userName);
 
   useEffect(() => {
+    let cancelled = false;
     const timer = window.setTimeout(() => {
-      setUserName(getOrCreateStoredUserName());
+      if (!cancelled) {
+        setUserName(getOrCreateStoredUserName());
+      }
     }, 0);
-    return () => window.clearTimeout(timer);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
   }, []);
 
   const showOliviaPicker = coachParam === "olivia" && !selectedMode;

--- a/components/voice-coach/voice-coach-page.tsx
+++ b/components/voice-coach/voice-coach-page.tsx
@@ -56,21 +56,19 @@ export function VoiceCoachPage() {
     [modeParam, coachParam],
   );
 
-  const [mounted, setMounted] = useState(false);
   const [pickedMode, setPickedMode] = useState<VoiceCoachMode | null>(null);
-  const [modeFromUrl, setModeFromUrl] = useState<VoiceCoachMode | null>(null);
-  const selectedMode = pickedMode ?? modeFromUrl;
+  const selectedMode = pickedMode ?? initialMode;
   const [userName, setUserName] = useState("Guest");
-  const showGuestBanner = mounted && isAnonymousVoiceCoachUser(userName);
+  const showGuestBanner = isAnonymousVoiceCoachUser(userName);
 
   useEffect(() => {
-    setMounted(true);
-    setModeFromUrl(initialMode);
-    setUserName(getOrCreateStoredUserName());
-  }, [initialMode]);
+    const timer = window.setTimeout(() => {
+      setUserName(getOrCreateStoredUserName());
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, []);
 
-  const showOliviaPicker =
-    mounted && coachParam === "olivia" && !selectedMode;
+  const showOliviaPicker = coachParam === "olivia" && !selectedMode;
 
   return (
     <div

--- a/components/voice-coach/voice-coach-session.tsx
+++ b/components/voice-coach/voice-coach-session.tsx
@@ -387,6 +387,7 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
   const [connectHint, setConnectHint] = useState<string | null>(null);
   const [task, setTask] = useState<string | null>(null);
   const [summary, setSummary] = useState<string | null>(null);
+  const [autoEndedByVoice, setAutoEndedByVoice] = useState(false);
   const [messages, setMessages] = useState<ConversationMessage[]>([]);
   const [historyItems, setHistoryItems] = useState<VoiceCoachHistoryItem[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
@@ -468,6 +469,7 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
       title: `Current: ${title}`,
       mode,
       summary: null,
+      task: null,
       transcript,
       createdAt: null,
       durationSeconds: null,
@@ -719,6 +721,7 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
     setPhase("loading");
     setTask(null);
     setSummary(null);
+    setAutoEndedByVoice(false);
     setMessages([]);
     transcriptRef.current = [];
 
@@ -837,6 +840,7 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
     pendingConnectRef.current = null;
     negotiationRetriesRef.current = 0;
     setConnectHint(null);
+    setAutoEndedByVoice(triggeredByVoiceIntent);
     autoEndingRef.current = true;
     setPhase("ending");
     const conversationId = getConversationId();
@@ -929,6 +933,11 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
               <Sparkles className="h-3.5 w-3.5" />
               Session complete
             </p>
+            {autoEndedByVoice && (
+              <p className="mt-2 inline-flex items-center gap-2 rounded-full border border-blue-500/35 bg-blue-500/10 px-3 py-1 text-xs font-medium text-blue-200">
+                Auto-ended by voice command
+              </p>
+            )}
             <h2 className="mt-3 text-2xl font-bold text-white">
               Great work today in {mode}
             </h2>
@@ -940,6 +949,7 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
                 setPhase("idle");
                 setTask(null);
                 setSummary(null);
+                setAutoEndedByVoice(false);
               }}
             />
           </div>
@@ -1180,10 +1190,13 @@ function HistorySidebar({
 }) {
   return (
     <aside className="overflow-hidden rounded-2xl border border-white/10 bg-[#0b0b0f]">
-      <div className="border-b border-white/10 px-4 py-3">
+      <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
         <p className="text-xs font-semibold uppercase tracking-wide text-[#9ca3af]">
           Chat History
         </p>
+        <span className="rounded-full border border-[#8b5cf6]/35 bg-[#8b5cf6]/15 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-[#d8b4fe]">
+          New Chat
+        </span>
       </div>
       <div className="max-h-[74vh] space-y-2 overflow-y-auto p-3">
         {historyLoading && (
@@ -1208,11 +1221,17 @@ function HistorySidebar({
             onClick={() => onSelect(item.id)}
             className={`w-full rounded-lg border px-3 py-2 text-left transition-colors ${
               selectedHistoryId === item.id
-                ? "border-[#8b5cf6]/40 bg-[#8b5cf6]/15"
+                ? "border-[#8b5cf6]/55 bg-[#8b5cf6]/20 shadow-[0_0_0_1px_rgba(139,92,246,0.35)]"
                 : "border-white/10 bg-[#111114] hover:bg-white/[0.04]"
             }`}
           >
-            <p className="text-xs text-[#9ca3af]">{item.mode}</p>
+            <p
+              className={`text-xs ${
+                selectedHistoryId === item.id ? "text-[#c4b5fd]" : "text-[#9ca3af]"
+              }`}
+            >
+              {item.mode}
+            </p>
             <p className="mt-1 text-sm font-medium text-white">
               {formatConversationTitle(item, index)}
             </p>
@@ -1246,6 +1265,11 @@ function HistoryContent({
         </p>
         {selectedHistoryItem?.summary && (
           <p className="mt-1 text-xs text-[#9ca3af]">{selectedHistoryItem.summary}</p>
+        )}
+        {selectedHistoryItem?.task && (
+          <p className="mt-2 inline-flex max-w-full items-center rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-1 text-[11px] text-amber-200">
+            Task: {selectedHistoryItem.task}
+          </p>
         )}
       </div>
       <div className="max-h-[42vh] space-y-3 overflow-y-auto px-5 py-4">

--- a/components/voice-coach/voice-coach-session.tsx
+++ b/components/voice-coach/voice-coach-session.tsx
@@ -716,12 +716,6 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
   }, []);
 
   useEffect(() => {
-    if (!avatarIsActive) {
-      setAvatarMouthLevel(0);
-      setAvatarHeadMotionClass("rotate-0 translate-y-0");
-      return;
-    }
-
     let cancelled = false;
     const listeningPoses = ["rotate-0 translate-y-0", "rotate-[1deg] -translate-y-[1px]", "rotate-[-1deg] translate-y-0"] as const;
     const speakingPoses = ["rotate-[1deg] -translate-y-[1px]", "rotate-[-1deg] -translate-y-[1px]", "rotate-0 -translate-y-[1px]"] as const;
@@ -733,7 +727,11 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
         : 0;
       setAvatarMouthLevel(mouthFrame);
 
-      const poses = avatarIsSpeaking ? speakingPoses : listeningPoses;
+      const poses = avatarIsSpeaking
+        ? speakingPoses
+        : avatarIsActive
+          ? listeningPoses
+          : (["rotate-0 translate-y-0"] as const);
       setAvatarHeadMotionClass(poses[Math.floor(Math.random() * poses.length)]);
     }, avatarIsSpeaking ? 140 : 620);
 
@@ -1259,9 +1257,9 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
               avatar={coachAvatar}
               speaking={avatarIsSpeaking}
               blinking={avatarBlinking}
-              mouthLevel={avatarMouthLevel}
+              mouthLevel={avatarIsActive ? avatarMouthLevel : 0}
               gaze={avatarGaze}
-              headMotionClass={avatarHeadMotionClass}
+              headMotionClass={avatarIsActive ? avatarHeadMotionClass : "rotate-0 translate-y-0"}
               size="large"
             />
             <span

--- a/components/voice-coach/voice-coach-session.tsx
+++ b/components/voice-coach/voice-coach-session.tsx
@@ -66,6 +66,30 @@ function getErrorContextText(context: unknown): string {
   }
 }
 
+const RETRY_CLOSE_DELAY_MS = 400;
+
+type ConversationHandle = ReturnType<typeof useConversation>;
+
+function delayMs(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+function isSdkConnected(conv: ConversationHandle | null | undefined): boolean {
+  return conv?.status === "connected";
+}
+
+function isWebSocketClosedError(message: string, context?: unknown): boolean {
+  const combined = `${message} ${getErrorContextText(context)}`.toLowerCase();
+  return (
+    combined.includes("closing or closed") ||
+    combined.includes("websocket is already") ||
+    combined.includes("closed before session start") ||
+    combined.includes("already in closing")
+  );
+}
+
 function isRetryableStartupFailure(message: string, context?: unknown): boolean {
   const combined = `${message} ${getErrorContextText(context)}`.toLowerCase();
   return (
@@ -383,23 +407,14 @@ function CoachFace({
 }
 
 export function VoiceCoachSession({ mode }: VoiceCoachSessionProps) {
-  const [sessionInstanceKey, setSessionInstanceKey] = useState(0);
-
   return (
-    <ConversationProvider key={sessionInstanceKey}>
-      <VoiceCoachSessionInner
-        mode={mode}
-        onRemountSdk={() => setSessionInstanceKey((key) => key + 1)}
-      />
+    <ConversationProvider>
+      <VoiceCoachSessionInner mode={mode} />
     </ConversationProvider>
   );
 }
 
-interface VoiceCoachSessionInnerProps extends VoiceCoachSessionProps {
-  onRemountSdk: () => void;
-}
-
-function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerProps) {
+function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
   const [phase, setPhase] = useState<SessionPhase>("idle");
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -424,15 +439,44 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
   const pendingConnectRef = useRef<PendingConnect | null>(null);
   const negotiationRetriesRef = useRef(0);
   const loadingPublicRetryRef = useRef(false);
-  const loadingSawNonDisconnectedStatusRef = useRef(false);
   const loadingFailureHandledRef = useRef(false);
   const isStartingRef = useRef(false);
   const startAttemptCounterRef = useRef(0);
   const activeStartAttemptRef = useRef(0);
   const sessionStartedRef = useRef(false);
   const autoEndingRef = useRef(false);
+  const conversationIdRef = useRef<string | null>(null);
+  const conversationRef = useRef<ConversationHandle | null>(null);
+  const isMountedRef = useRef(false);
+  const connectionLockRef = useRef(false);
+  const onConnectRef = useRef<() => void>(() => undefined);
+  const onDisconnectRef = useRef<() => void>(() => undefined);
+  const onMessageRef = useRef<(message: unknown) => void>(() => undefined);
+  const onErrorRef = useRef<(message: string, context: unknown) => void>(() => undefined);
+  const [storedConversationId, setStoredConversationId] = useState<string | null>(
+    null,
+  );
 
   const historyLoadGenerationRef = useRef(0);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      historyLoadGenerationRef.current += 1;
+      activeStartAttemptRef.current = ++startAttemptCounterRef.current;
+      connectionLockRef.current = false;
+      void (async () => {
+        const conv = conversationRef.current;
+        if (!conv || conv.status === "disconnected") return;
+        try {
+          await conv.endSession();
+        } catch {
+          // Socket may already be closed — stopping mic is best-effort on unmount.
+        }
+      })();
+    };
+  }, []);
 
   const loadHistory = useCallback(async () => {
     const userName = getOrCreateStoredUserName();
@@ -461,7 +505,7 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
         throw new Error(data.error ?? "Failed to load chat history");
       }
 
-      if (isStale()) return;
+      if (isStale() || !isMountedRef.current) return;
 
       setHistoryItems(data.items ?? []);
       if (data.warning) {
@@ -470,7 +514,7 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
         setHistoryError("History is temporarily unavailable.");
       }
     } catch (err) {
-      if (isStale()) return;
+      if (isStale() || !isMountedRef.current) return;
 
       const message =
         err instanceof Error ? err.message : "Failed to load chat history";
@@ -487,7 +531,7 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
           : message,
       );
     } finally {
-      if (!isStale()) {
+      if (!isStale() && isMountedRef.current) {
         setHistoryLoading(false);
       }
     }
@@ -495,11 +539,12 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      void loadHistory();
+      if (isMountedRef.current) {
+        void loadHistory();
+      }
     }, 0);
     return () => {
       window.clearTimeout(timer);
-      historyLoadGenerationRef.current += 1;
     };
   }, [loadHistory]);
 
@@ -598,106 +643,238 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
         retryErr,
       ),
     );
+    if (!isMountedRef.current) return;
     phaseRef.current = "idle";
     setPhase("idle");
+    conversationIdRef.current = null;
+    setStoredConversationId(null);
   }, []);
 
-  const conversation = useConversation({
-    onConnect: () => {
-      negotiationRetriesRef.current = 0;
-      pendingConnectRef.current = null;
-      sessionStartedRef.current = true;
-      loadingFailureHandledRef.current = false;
-      loadingSawNonDisconnectedStatusRef.current = false;
-      activeConnectedAtRef.current = Date.now();
-      setConnectHint(null);
-      phaseRef.current = "active";
-      setPhase("active");
-      setError(null);
-    },
-    onDisconnect: () => {
+  const endSdkSessionIfOpen = useCallback(async () => {
+    const conv = conversationRef.current;
+    if (!conv || conv.status === "disconnected") {
       sessionStartedRef.current = false;
-      if (phaseRef.current === "loading") {
-        // During loading, disconnect events can be transient while handshake settles.
-        // Let startup pipeline / timeout set the final state deterministically.
+      connectionLockRef.current = false;
+      return;
+    }
+    try {
+      await conv.endSession();
+    } catch (err) {
+      console.warn("[voice-coach] endSession skipped:", err);
+    } finally {
+      sessionStartedRef.current = false;
+      connectionLockRef.current = false;
+    }
+    await delayMs(RETRY_CLOSE_DELAY_MS);
+  }, []);
+
+  const startSdkSession = useCallback(
+    async (options: Parameters<ConversationHandle["startSession"]>[0]) => {
+      const conv = conversationRef.current;
+      if (!conv) {
+        throw new Error("Voice SDK not ready");
+      }
+      if (isSdkConnected(conv)) {
         return;
       }
-      setPhase((current) => {
-        if (current === "active") {
-          phaseRef.current = "idle";
-          return "idle";
-        }
-        return current;
-      });
-    },
-    onMessage: (message) => {
-      const normalized = normalizeConversationMessage(message);
-      if (normalized) {
-        setMessages((current) => [...current, normalized]);
-        transcriptRef.current.push(`[${normalized.role}] ${normalized.text}`);
+      if (connectionLockRef.current) {
         return;
       }
-
-      const rawMessage: unknown = message;
-      const fallback = (
-        typeof rawMessage === "string"
-          ? rawMessage
-          : JSON.stringify(rawMessage ?? "")
-      ).trim();
-      if (fallback) {
-        transcriptRef.current.push(fallback);
+      connectionLockRef.current = true;
+      try {
+        await conv.startSession(options);
+      } catch (err) {
+        connectionLockRef.current = false;
+        throw err;
       }
     },
-    onError: (message, context) => {
-      console.error("[voice-coach] conversation error:", message, context);
+    [],
+  );
 
-      const pending = pendingConnectRef.current;
-      if (
-        phaseRef.current === "loading" &&
-        pending?.authMode === "signed" &&
-        pending.agentId &&
-        !loadingPublicRetryRef.current &&
-        isRetryableStartupFailure(message, context)
-      ) {
-        loadingPublicRetryRef.current = true;
-        pendingConnectRef.current = {
-          authMode: "public",
-          agentId: pending.agentId,
-          sessionOptions: pending.sessionOptions,
-        };
-        setConnectHint(
-          "Signed handshake failed. Retrying with public agent connection…",
+  onConnectRef.current = () => {
+    if (!isMountedRef.current) return;
+    connectionLockRef.current = false;
+    negotiationRetriesRef.current = 0;
+    pendingConnectRef.current = null;
+    sessionStartedRef.current = true;
+    loadingFailureHandledRef.current = false;
+    activeConnectedAtRef.current = Date.now();
+    setConnectHint(null);
+    phaseRef.current = "active";
+    setPhase("active");
+    setError(null);
+
+    try {
+      const id = conversationRef.current?.getId() || null;
+      conversationIdRef.current = id;
+      setStoredConversationId(id);
+    } catch (err) {
+      console.warn("[voice-coach] getId on connect skipped:", err);
+    }
+  };
+
+  onDisconnectRef.current = () => {
+    sessionStartedRef.current = false;
+    connectionLockRef.current = false;
+
+    if (!isMountedRef.current) {
+      void endSdkSessionIfOpen();
+      return;
+    }
+
+    if (phaseRef.current === "loading") {
+      void endSdkSessionIfOpen();
+      return;
+    }
+
+    if (
+      phaseRef.current === "ending" ||
+      phaseRef.current === "done" ||
+      autoEndingRef.current
+    ) {
+      return;
+    }
+
+    void (async () => {
+      await endSdkSessionIfOpen();
+      if (!isMountedRef.current) return;
+      if (phaseRef.current === "active") {
+        setNotice(
+          "Connection lost. Start again to continue, or End session to save.",
         );
+        phaseRef.current = "idle";
+        setPhase("idle");
+      }
+    })();
+  };
+
+  onMessageRef.current = (message: unknown) => {
+    if (!isMountedRef.current) return;
+    if (!isSdkConnected(conversationRef.current)) return;
+
+    const normalized = normalizeConversationMessage(message);
+    if (normalized) {
+      setMessages((current) => [...current, normalized]);
+      transcriptRef.current.push(`[${normalized.role}] ${normalized.text}`);
+      return;
+    }
+
+    const fallback = (
+      typeof message === "string" ? message : JSON.stringify(message ?? "")
+    ).trim();
+    if (fallback) {
+      transcriptRef.current.push(fallback);
+    }
+  };
+
+  onErrorRef.current = (message: string, context: unknown) => {
+    if (!isMountedRef.current) return;
+
+    if (isWebSocketClosedError(message, context)) {
+      void (async () => {
+        await endSdkSessionIfOpen();
+        if (!isMountedRef.current) return;
+        if (phaseRef.current === "active") {
+          setNotice(
+            "Voice connection closed. Check that your ElevenLabs agent is Public, then start again.",
+          );
+          phaseRef.current = "idle";
+          setPhase("idle");
+        }
+      })();
+      return;
+    }
+
+    console.error("[voice-coach] conversation error:", message, context);
+
+    const pending = pendingConnectRef.current;
+    if (
+      phaseRef.current === "loading" &&
+      pending?.authMode === "signed" &&
+      pending.agentId &&
+      !loadingPublicRetryRef.current &&
+      isRetryableStartupFailure(message, context)
+    ) {
+      loadingPublicRetryRef.current = true;
+      pendingConnectRef.current = {
+        authMode: "public",
+        agentId: pending.agentId,
+        sessionOptions: pending.sessionOptions,
+      };
+      setConnectHint(
+        "Signed handshake failed. Retrying with public agent connection…",
+      );
+      const publicPending = {
+        authMode: "public" as const,
+        agentId: pending.agentId,
+        sessionOptions: pending.sessionOptions,
+      };
+      void (async () => {
+        await endSdkSessionIfOpen();
+        if (
+          !isMountedRef.current ||
+          phaseRef.current !== "loading" ||
+          !pendingConnectRef.current
+        ) {
+          return;
+        }
         try {
-          void conversation.startSession({
-            agentId: pending.agentId,
+          await startSdkSession({
+            agentId: publicPending.agentId,
             connectionType: "websocket",
-            ...pending.sessionOptions,
+            ...publicPending.sessionOptions,
           });
         } catch (retryErr) {
-          handleFallbackStartFailure(retryErr);
+          if (isMountedRef.current) {
+            handleFallbackStartFailure(retryErr);
+          }
         }
-        return;
-      }
+      })();
+      return;
+    }
 
-      loadingFailureHandledRef.current = true;
-      pendingConnectRef.current = null;
-      negotiationRetriesRef.current = 0;
-      sessionStartedRef.current = false;
-      loadingPublicRetryRef.current = false;
-      setConnectHint(null);
-      setError(formatVoiceCoachConnectionError(message, context));
-      phaseRef.current = "idle";
-      setPhase("idle");
-    },
+    if (phaseRef.current === "active" || phaseRef.current === "ending") {
+      void endSdkSessionIfOpen();
+      setNotice(
+        `Connection issue: ${formatVoiceCoachConnectionError(message, context).split("\n")[0]}`,
+      );
+      if (phaseRef.current === "active") {
+        phaseRef.current = "idle";
+        setPhase("idle");
+      }
+      return;
+    }
+
+    loadingFailureHandledRef.current = true;
+    pendingConnectRef.current = null;
+    negotiationRetriesRef.current = 0;
+    sessionStartedRef.current = false;
+    loadingPublicRetryRef.current = false;
+    connectionLockRef.current = false;
+    setConnectHint(null);
+    setError(formatVoiceCoachConnectionError(message, context));
+    phaseRef.current = "idle";
+    setPhase("idle");
+    void endSdkSessionIfOpen();
+  };
+
+  const conversation = useConversation({
+    onConnect: () => onConnectRef.current(),
+    onDisconnect: () => onDisconnectRef.current(),
+    onMessage: (message) => onMessageRef.current(message),
+    onError: (message, context) => onErrorRef.current(message, context),
   });
+
+  useEffect(() => {
+    conversationRef.current = conversation;
+  }, [conversation]);
 
   useEffect(() => {
     if (phase !== "loading") return;
 
     const timeoutMs = 25_000;
     const timer = window.setTimeout(() => {
-      if (phaseRef.current !== "loading") return;
+      if (!isMountedRef.current || phaseRef.current !== "loading") return;
 
       pendingConnectRef.current = null;
       negotiationRetriesRef.current = 0;
@@ -705,6 +882,9 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
       loadingPublicRetryRef.current = false;
       loadingFailureHandledRef.current = true;
       isStartingRef.current = false;
+      connectionLockRef.current = false;
+      conversationIdRef.current = null;
+      setStoredConversationId(null);
       setConnectHint(null);
       setNotice(null);
       setError(
@@ -712,17 +892,31 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
           "NegotiationError: negotiation timed out /rtc/v1/validate v1 RTC path not found",
         ),
       );
-      try {
-        conversation.endSession();
-      } catch (err) {
-        console.warn("[voice-coach] endSession skipped:", err);
-      }
-      phaseRef.current = "idle";
-      setPhase("idle");
+      void endSdkSessionIfOpen().then(() => {
+        if (!isMountedRef.current || phaseRef.current !== "loading") return;
+        phaseRef.current = "idle";
+        setPhase("idle");
+      });
     }, timeoutMs);
 
     return () => window.clearTimeout(timer);
-  }, [conversation, phase]);
+  }, [endSdkSessionIfOpen, phase]);
+
+  const prevModeRef = useRef(mode);
+  useEffect(() => {
+    if (prevModeRef.current === mode) return;
+    prevModeRef.current = mode;
+    activeStartAttemptRef.current = ++startAttemptCounterRef.current;
+    if (phaseRef.current !== "active" && phaseRef.current !== "loading") {
+      return;
+    }
+    void endSdkSessionIfOpen().then(() => {
+      if (!isMountedRef.current) return;
+      setNotice("Practice mode changed. Start again to connect.");
+      phaseRef.current = "idle";
+      setPhase("idle");
+    });
+  }, [endSdkSessionIfOpen, mode]);
 
   const avatarIsActive = phase === "active" || phase === "ending";
   const avatarIsSpeaking = avatarIsActive && conversation.isSpeaking;
@@ -776,104 +970,22 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
     };
   }, [avatarIsActive, avatarIsSpeaking]);
 
-  const safeEndConversation = useCallback(() => {
-    try {
-      conversation.endSession();
-    } catch (err) {
-      console.warn("[voice-coach] endSession skipped:", err);
-    } finally {
-      sessionStartedRef.current = false;
-      pendingConnectRef.current = null;
-      isStartingRef.current = false;
-      loadingPublicRetryRef.current = false;
-      loadingFailureHandledRef.current = false;
-      loadingSawNonDisconnectedStatusRef.current = false;
-    }
-  }, [conversation]);
-
-  const cancelConnecting = useCallback(() => {
-    if (phaseRef.current !== "loading") return;
-
-    activeStartAttemptRef.current = ++startAttemptCounterRef.current;
-    safeEndConversation();
-    negotiationRetriesRef.current = 0;
-    setConnectHint(null);
-    setNotice(null);
-    phaseRef.current = "idle";
-    setPhase("idle");
-  }, [safeEndConversation]);
-
-  useEffect(() => {
-    if (phase !== "loading" || loadingFailureHandledRef.current) {
-      return;
-    }
-
-    if (conversation.status !== "disconnected") {
-      loadingSawNonDisconnectedStatusRef.current = true;
-      return;
-    }
-
-    const hasStartedNegotiation = loadingSawNonDisconnectedStatusRef.current;
-    const exceededGracePeriod = Date.now() - startedAtRef.current > 4_000;
-    if (!hasStartedNegotiation || !exceededGracePeriod) {
-      return;
-    }
-
-    loadingFailureHandledRef.current = true;
-
-    const pending = pendingConnectRef.current;
-    if (
-      pending?.authMode === "signed" &&
-      pending.agentId &&
-      !loadingPublicRetryRef.current
-    ) {
-      loadingPublicRetryRef.current = true;
-      pendingConnectRef.current = {
-        authMode: "public",
-        agentId: pending.agentId,
-        sessionOptions: pending.sessionOptions,
-      };
-      setConnectHint(
-        "Signed handshake stalled. Retrying with public agent connection…",
-      );
-      void conversation.startSession({
-        agentId: pending.agentId,
-        connectionType: "websocket",
-        ...pending.sessionOptions,
-      });
-      return;
-    }
-
-    pendingConnectRef.current = null;
-    negotiationRetriesRef.current = 0;
-    sessionStartedRef.current = false;
-    loadingPublicRetryRef.current = false;
-    isStartingRef.current = false;
-    setConnectHint(null);
-    setNotice(null);
-    setError(
-      formatVoiceCoachConnectionError(
-        "NegotiationError: negotiation timed out /rtc/v1/validate v1 RTC path not found",
-      ),
-    );
-    safeEndConversation();
-    phaseRef.current = "idle";
-    setPhase("idle");
-  }, [conversation, conversation.status, phase, safeEndConversation]);
-
-  useEffect(() => {
-    return () => {
-      pendingConnectRef.current = null;
-      negotiationRetriesRef.current = 0;
-      autoEndingRef.current = false;
-      safeEndConversation();
-    };
-  }, [safeEndConversation]);
-
   const getConversationId = useCallback((): string | undefined => {
-    if (!sessionStartedRef.current) return undefined;
+    if (conversationIdRef.current) {
+      return conversationIdRef.current;
+    }
+    if (conversation.status !== "connected") {
+      return undefined;
+    }
     try {
-      return conversation.getId() || undefined;
+      const id = conversation.getId() || undefined;
+      if (id) {
+        conversationIdRef.current = id;
+        if (isMountedRef.current) {
+          setStoredConversationId(id);
+        }
+      }
+      return id;
     } catch (err) {
       console.warn("[voice-coach] getId skipped:", err);
       return undefined;
@@ -881,9 +993,7 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
   }, [conversation]);
 
   const startSession = useCallback(async () => {
-    if (phaseRef.current === "loading") {
-      cancelConnecting();
-    } else if (isStartingRef.current) {
+    if (isStartingRef.current || phaseRef.current === "loading") {
       setNotice("A connection attempt is already in progress...");
       return;
     }
@@ -893,16 +1003,16 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
     activeStartAttemptRef.current = startAttemptId;
 
     getOrCreateStoredUserName();
-    safeEndConversation();
     setError(null);
     setNotice(null);
     setConnectHint(null);
     negotiationRetriesRef.current = 0;
     loadingPublicRetryRef.current = false;
-    loadingSawNonDisconnectedStatusRef.current = false;
     loadingFailureHandledRef.current = false;
     pendingConnectRef.current = null;
     sessionStartedRef.current = false;
+    conversationIdRef.current = null;
+    setStoredConversationId(null);
     activeConnectedAtRef.current = 0;
     autoEndingRef.current = false;
     phaseRef.current = "loading";
@@ -915,15 +1025,17 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
     transcriptRef.current = [];
 
     try {
-      const permissionStream = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          echoCancellation: true,
-          noiseSuppression: true,
-          autoGainControl: true,
-          channelCount: 1,
-        },
-      });
-      permissionStream.getTracks().forEach((track) => track.stop());
+      await endSdkSessionIfOpen();
+      if (!isMountedRef.current || activeStartAttemptRef.current !== startAttemptId) {
+        return;
+      }
+      if (isSdkConnected(conversationRef.current)) {
+        phaseRef.current = "active";
+        setPhase("active");
+        return;
+      }
+
+      await navigator.mediaDevices.getUserMedia({ audio: true });
 
       const res = await fetch(
         `/api/voice-coach/signed-url?mode=${encodeURIComponent(mode)}`,
@@ -942,7 +1054,9 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
       if (!res.ok) {
         throw new Error(data.error ?? "Failed to start session");
       }
-      if (activeStartAttemptRef.current !== startAttemptId) return;
+      if (!isMountedRef.current || activeStartAttemptRef.current !== startAttemptId) {
+        return;
+      }
 
       if (!data.memory) {
         throw new Error("Invalid session response from server");
@@ -964,7 +1078,6 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
       startedAtRef.current = Date.now();
 
       const sessionOptions = {
-        serverLocation: "in-residency" as const,
         dynamicVariables: {
           mode,
           memory: data.memory,
@@ -994,26 +1107,28 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
 
       pendingConnectRef.current = pending;
       if (pending.authMode === "signed" && pending.signedUrl) {
-        await conversation.startSession({
+        await startSdkSession({
           signedUrl: pending.signedUrl,
-          connectionType: "websocket",
           ...pending.sessionOptions,
         });
       } else if (pending.authMode === "public" && pending.agentId) {
-        loadingPublicRetryRef.current = true;
-        await conversation.startSession({
+        await startSdkSession({
           agentId: pending.agentId,
-          connectionType: "websocket",
           ...pending.sessionOptions,
         });
       }
     } catch (err) {
-      if (activeStartAttemptRef.current !== startAttemptId) return;
+      if (!isMountedRef.current || activeStartAttemptRef.current !== startAttemptId) {
+        return;
+      }
       console.error("[voice-coach] start failed:", err);
+      connectionLockRef.current = false;
+      await endSdkSessionIfOpen();
       pendingConnectRef.current = null;
       sessionStartedRef.current = false;
+      conversationIdRef.current = null;
+      setStoredConversationId(null);
       loadingPublicRetryRef.current = false;
-      safeEndConversation();
       setConnectHint(null);
       setError(
         formatVoiceCoachConnectionError(
@@ -1024,18 +1139,27 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
       phaseRef.current = "idle";
       setPhase("idle");
     } finally {
-      if (activeStartAttemptRef.current === startAttemptId) {
+      if (
+        isMountedRef.current &&
+        activeStartAttemptRef.current === startAttemptId
+      ) {
         isStartingRef.current = false;
       }
     }
-  }, [cancelConnecting, conversation, mode, safeEndConversation]);
+  }, [endSdkSessionIfOpen, mode, startSdkSession]);
 
   const endSession = useCallback(async (triggeredByVoiceIntent = false) => {
     const userName = getStoredUserName() ?? getOrCreateStoredUserName();
     if (!userName) return;
 
-    if (phaseRef.current !== "active" && !sessionStartedRef.current) {
-      console.warn("[voice-coach] endSession called with no active conversation");
+    const conversationId =
+      conversationIdRef.current ?? storedConversationId ?? getConversationId();
+
+    if (
+      phaseRef.current !== "active" &&
+      phaseRef.current !== "ending" &&
+      !conversationId
+    ) {
       return;
     }
 
@@ -1045,19 +1169,32 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
     setConnectHint(null);
     setAutoEndedByVoice(triggeredByVoiceIntent);
     autoEndingRef.current = true;
+    phaseRef.current = "ending";
     setPhase("ending");
-    const conversationId = getConversationId();
+
     if (!conversationId) {
-      console.warn("[voice-coach] endSession skipped: missing conversation id");
-      safeEndConversation();
+      sessionStartedRef.current = false;
       setError("No active conversation found. Start a new session and try again.");
       phaseRef.current = "idle";
       setPhase("idle");
       isStartingRef.current = false;
+      autoEndingRef.current = false;
       return;
     }
 
-    safeEndConversation();
+    if (conversation.status !== "disconnected") {
+      try {
+        await conversation.endSession();
+      } catch (err) {
+        console.warn("[voice-coach] endSession skipped:", err);
+      }
+    }
+    sessionStartedRef.current = false;
+
+    if (!isMountedRef.current) {
+      autoEndingRef.current = false;
+      return;
+    }
 
     const durationSeconds = Math.round(
       (Date.now() - startedAtRef.current) / 1000,
@@ -1093,6 +1230,8 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
         throw new Error(data.error ?? "Failed to save session");
       }
 
+      if (!isMountedRef.current) return;
+
       setTask(data.task ?? null);
       setSummary(data.summary ?? null);
       if (data.warning) {
@@ -1102,9 +1241,12 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
       } else {
         setNotice(null);
       }
+      conversationIdRef.current = null;
+      setStoredConversationId(null);
       setPhase("done");
       void loadHistory();
     } catch (err) {
+      if (!isMountedRef.current) return;
       console.error("[voice-coach] end session failed:", err);
       setError(
         formatVoiceCoachConnectionError(
@@ -1115,10 +1257,12 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
       phaseRef.current = "idle";
       setPhase("idle");
     } finally {
-      autoEndingRef.current = false;
-      isStartingRef.current = false;
+      if (isMountedRef.current) {
+        autoEndingRef.current = false;
+        isStartingRef.current = false;
+      }
     }
-  }, [getConversationId, loadHistory, mode, safeEndConversation]);
+  }, [conversation, getConversationId, loadHistory, mode, storedConversationId]);
 
   const coachAvatar = MODE_COACH_AVATAR[mode];
 
@@ -1150,22 +1294,16 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
             {task && <HomeworkCard task={task} mode={mode} />}
             <SessionActions
               onPracticeAgain={() => {
-                safeEndConversation();
-                negotiationRetriesRef.current = 0;
-                pendingConnectRef.current = null;
-                isStartingRef.current = false;
-                loadingFailureHandledRef.current = false;
-                loadingSawNonDisconnectedStatusRef.current = false;
-                loadingPublicRetryRef.current = false;
-                setError(null);
-                setNotice(null);
-                setConnectHint(null);
                 phaseRef.current = "idle";
                 setPhase("idle");
                 setTask(null);
                 setSummary(null);
                 setAutoEndedByVoice(false);
-                onRemountSdk();
+                setError(null);
+                setNotice(null);
+                setConnectHint(null);
+                conversationIdRef.current = null;
+                setStoredConversationId(null);
               }}
             />
           </div>
@@ -1180,16 +1318,27 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
     );
   }
 
+  const sdkConnected = conversation.status === "connected";
+  const isLive = phase === "active" && sdkConnected;
   const isActive = phase === "active" || phase === "ending";
   const isLoading = phase === "loading" || phase === "ending";
-  const heading = getSessionHeading(isActive, isLoading);
+  const canEndSession =
+    isLive ||
+    phase === "ending" ||
+    (Boolean(storedConversationId) &&
+      (phase === "active" || phase === "idle"));
+  const showStartButton =
+    phase === "idle" ||
+    phase === "loading" ||
+    (phase === "active" && !sdkConnected);
+  const heading = getSessionHeading(isLive, isLoading);
   const description = getSessionDescription(
-    isActive,
+    isLive,
     isLoading,
     conversation.isSpeaking,
     connectHint,
   );
-  const isConnected = conversation.status === "connected" || isActive;
+  const isConnected = sdkConnected;
   const liveStateLabel = isConnected
     ? conversation.isSpeaking
       ? "Connected · Coach speaking"
@@ -1356,24 +1505,18 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
       </p>
 
             <div className="mt-6 flex flex-wrap justify-center gap-3">
-              {!isActive ? (
+              {showStartButton ? (
                 <button
                   type="button"
-                  onClick={() => {
-                    if (phase === "loading") {
-                      cancelConnecting();
-                    } else {
-                      void startSession();
-                    }
-                  }}
-                  className="inline-flex items-center gap-2 rounded-xl bg-[#8b5cf6] px-6 py-3 text-sm font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-[#7c3aed]"
+                  onClick={() => void startSession()}
+                  disabled={isLoading}
+                  className="inline-flex items-center gap-2 rounded-xl bg-[#8b5cf6] px-6 py-3 text-sm font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-[#7c3aed] disabled:opacity-50"
                 >
                   <Mic className="h-4 w-4" />
-                  {phase === "loading"
-                    ? "Cancel"
-                    : "Start Practicing Free"}
+                  {isLoading ? "Connecting…" : "Start Practicing Free"}
                 </button>
-              ) : (
+              ) : null}
+              {canEndSession ? (
                 <button
                   type="button"
                   onClick={() => void endSession(false)}
@@ -1383,7 +1526,7 @@ function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerPr
                   <Square className="h-4 w-4" />
                   {phase === "ending" ? "Saving session…" : "End session"}
                 </button>
-              )}
+              ) : null}
               <button
                 type="button"
                 onClick={() => setShowMessages(true)}

--- a/components/voice-coach/voice-coach-session.tsx
+++ b/components/voice-coach/voice-coach-session.tsx
@@ -383,14 +383,23 @@ function CoachFace({
 }
 
 export function VoiceCoachSession({ mode }: VoiceCoachSessionProps) {
+  const [sessionInstanceKey, setSessionInstanceKey] = useState(0);
+
   return (
-    <ConversationProvider>
-      <VoiceCoachSessionInner mode={mode} />
+    <ConversationProvider key={sessionInstanceKey}>
+      <VoiceCoachSessionInner
+        mode={mode}
+        onRemountSdk={() => setSessionInstanceKey((key) => key + 1)}
+      />
     </ConversationProvider>
   );
 }
 
-function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
+interface VoiceCoachSessionInnerProps extends VoiceCoachSessionProps {
+  onRemountSdk: () => void;
+}
+
+function VoiceCoachSessionInner({ mode, onRemountSdk }: VoiceCoachSessionInnerProps) {
   const [phase, setPhase] = useState<SessionPhase>("idle");
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -423,30 +432,36 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
   const sessionStartedRef = useRef(false);
   const autoEndingRef = useRef(false);
 
+  const historyLoadGenerationRef = useRef(0);
+
   const loadHistory = useCallback(async () => {
-    const userName = getStoredUserName();
-    if (!userName) {
-      setHistoryItems([]);
-      return;
-    }
+    const userName = getOrCreateStoredUserName();
+    const loadGeneration = ++historyLoadGenerationRef.current;
 
     setHistoryLoading(true);
     setHistoryError(null);
 
+    const isStale = () => loadGeneration !== historyLoadGenerationRef.current;
+
     try {
       const response = await fetch("/api/voice-coach/history", {
-        headers: voiceCoachHeaders(),
+        headers: { "x-user-name": userName },
       });
-      const data = (await response.json()) as {
+
+      if (isStale()) return;
+
+      const data = await parseApiJson<{
         items?: VoiceCoachHistoryItem[];
         error?: string;
         warning?: string;
         persisted?: boolean;
-      };
+      }>(response);
 
       if (!response.ok) {
         throw new Error(data.error ?? "Failed to load chat history");
       }
+
+      if (isStale()) return;
 
       setHistoryItems(data.items ?? []);
       if (data.warning) {
@@ -455,12 +470,26 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
         setHistoryError("History is temporarily unavailable.");
       }
     } catch (err) {
+      if (isStale()) return;
+
+      const message =
+        err instanceof Error ? err.message : "Failed to load chat history";
+      const isAbort =
+        (err instanceof DOMException && err.name === "AbortError") ||
+        message.toLowerCase().includes("aborted");
+
+      if (isAbort) return;
+
       console.error("[voice-coach] history load failed:", err);
       setHistoryError(
-        err instanceof Error ? err.message : "Failed to load chat history",
+        message === "Failed to fetch"
+          ? "Could not reach the server. Check your connection and that npm run dev is running."
+          : message,
       );
     } finally {
-      setHistoryLoading(false);
+      if (!isStale()) {
+        setHistoryLoading(false);
+      }
     }
   }, []);
 
@@ -468,7 +497,10 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
     const timer = window.setTimeout(() => {
       void loadHistory();
     }, 0);
-    return () => window.clearTimeout(timer);
+    return () => {
+      window.clearTimeout(timer);
+      historyLoadGenerationRef.current += 1;
+    };
   }, [loadHistory]);
 
   const liveConversationItem = useMemo(() => {
@@ -670,6 +702,9 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
       pendingConnectRef.current = null;
       negotiationRetriesRef.current = 0;
       sessionStartedRef.current = false;
+      loadingPublicRetryRef.current = false;
+      loadingFailureHandledRef.current = true;
+      isStartingRef.current = false;
       setConnectHint(null);
       setNotice(null);
       setError(
@@ -742,22 +777,31 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
   }, [avatarIsActive, avatarIsSpeaking]);
 
   const safeEndConversation = useCallback(() => {
-    const shouldAttemptEnd =
-      sessionStartedRef.current ||
-      conversation.status === "connected" ||
-      phaseRef.current === "loading" ||
-      phaseRef.current === "active" ||
-      phaseRef.current === "ending";
-    if (!shouldAttemptEnd) return;
-
     try {
       conversation.endSession();
     } catch (err) {
       console.warn("[voice-coach] endSession skipped:", err);
     } finally {
       sessionStartedRef.current = false;
+      pendingConnectRef.current = null;
+      isStartingRef.current = false;
+      loadingPublicRetryRef.current = false;
+      loadingFailureHandledRef.current = false;
+      loadingSawNonDisconnectedStatusRef.current = false;
     }
   }, [conversation]);
+
+  const cancelConnecting = useCallback(() => {
+    if (phaseRef.current !== "loading") return;
+
+    activeStartAttemptRef.current = ++startAttemptCounterRef.current;
+    safeEndConversation();
+    negotiationRetriesRef.current = 0;
+    setConnectHint(null);
+    setNotice(null);
+    phaseRef.current = "idle";
+    setPhase("idle");
+  }, [safeEndConversation]);
 
   useEffect(() => {
     if (phase !== "loading" || loadingFailureHandledRef.current) {
@@ -804,6 +848,7 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
     negotiationRetriesRef.current = 0;
     sessionStartedRef.current = false;
     loadingPublicRetryRef.current = false;
+    isStartingRef.current = false;
     setConnectHint(null);
     setNotice(null);
     setError(
@@ -814,13 +859,7 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
     safeEndConversation();
     phaseRef.current = "idle";
     setPhase("idle");
-  }, [
-    conversation,
-    conversation.status,
-    handleFallbackStartFailure,
-    phase,
-    safeEndConversation,
-  ]);
+  }, [conversation, conversation.status, phase, safeEndConversation]);
 
   useEffect(() => {
     return () => {
@@ -842,7 +881,9 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
   }, [conversation]);
 
   const startSession = useCallback(async () => {
-    if (isStartingRef.current || phaseRef.current === "loading") {
+    if (phaseRef.current === "loading") {
+      cancelConnecting();
+    } else if (isStartingRef.current) {
       setNotice("A connection attempt is already in progress...");
       return;
     }
@@ -987,7 +1028,7 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
         isStartingRef.current = false;
       }
     }
-  }, [conversation, mode, safeEndConversation]);
+  }, [cancelConnecting, conversation, mode, safeEndConversation]);
 
   const endSession = useCallback(async (triggeredByVoiceIntent = false) => {
     const userName = getStoredUserName() ?? getOrCreateStoredUserName();
@@ -1012,6 +1053,7 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
       setError("No active conversation found. Start a new session and try again.");
       phaseRef.current = "idle";
       setPhase("idle");
+      isStartingRef.current = false;
       return;
     }
 
@@ -1074,6 +1116,7 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
       setPhase("idle");
     } finally {
       autoEndingRef.current = false;
+      isStartingRef.current = false;
     }
   }, [getConversationId, loadHistory, mode, safeEndConversation]);
 
@@ -1107,11 +1150,22 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
             {task && <HomeworkCard task={task} mode={mode} />}
             <SessionActions
               onPracticeAgain={() => {
+                safeEndConversation();
+                negotiationRetriesRef.current = 0;
+                pendingConnectRef.current = null;
+                isStartingRef.current = false;
+                loadingFailureHandledRef.current = false;
+                loadingSawNonDisconnectedStatusRef.current = false;
+                loadingPublicRetryRef.current = false;
+                setError(null);
+                setNotice(null);
+                setConnectHint(null);
                 phaseRef.current = "idle";
                 setPhase("idle");
                 setTask(null);
                 setSummary(null);
                 setAutoEndedByVoice(false);
+                onRemountSdk();
               }}
             />
           </div>
@@ -1305,12 +1359,19 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
               {!isActive ? (
                 <button
                   type="button"
-                  onClick={startSession}
-                  disabled={isLoading}
-                  className="inline-flex items-center gap-2 rounded-xl bg-[#8b5cf6] px-6 py-3 text-sm font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-[#7c3aed] disabled:opacity-50"
+                  onClick={() => {
+                    if (phase === "loading") {
+                      cancelConnecting();
+                    } else {
+                      void startSession();
+                    }
+                  }}
+                  className="inline-flex items-center gap-2 rounded-xl bg-[#8b5cf6] px-6 py-3 text-sm font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-[#7c3aed]"
                 >
                   <Mic className="h-4 w-4" />
-                  {isLoading ? "Connecting…" : "Start Practicing Free"}
+                  {phase === "loading"
+                    ? "Cancel"
+                    : "Start Practicing Free"}
                 </button>
               ) : (
                 <button

--- a/components/voice-coach/voice-coach-session.tsx
+++ b/components/voice-coach/voice-coach-session.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ConversationProvider, useConversation } from "@elevenlabs/react";
 import Link from "next/link";
 import {
+  MessageSquareText,
   Mic,
   Sparkles,
   Square,
@@ -53,6 +54,29 @@ interface PendingConnect {
 
 interface VoiceCoachSessionProps {
   mode: VoiceCoachMode;
+}
+
+function getErrorContextText(context: unknown): string {
+  if (context instanceof Error) return `${context.name} ${context.message}`;
+  if (typeof context === "string") return context;
+  try {
+    return JSON.stringify(context ?? "");
+  } catch {
+    return String(context ?? "");
+  }
+}
+
+function isRetryableStartupFailure(message: string, context?: unknown): boolean {
+  const combined = `${message} ${getErrorContextText(context)}`.toLowerCase();
+  return (
+    isNegotiationTimeout(message, context) ||
+    combined.includes("v1 rtc path not found") ||
+    combined.includes("/rtc/v1/validate") ||
+    combined.includes("unknown datachannel error") ||
+    combined.includes("websocket") ||
+    combined.includes("closed before session start") ||
+    combined.includes("did not complete")
+  );
 }
 
 const MODE_SURFACE_STYLES: Record<
@@ -209,20 +233,6 @@ function normalizeConversationMessage(message: unknown): ConversationMessage | n
   }
 
   return { role, text: text.trim(), timestamp: Date.now() };
-}
-
-function isSessionEndIntent(text: string): boolean {
-  const normalized = text.toLowerCase();
-  const patterns = [
-    /\blet'?s end (this|the)?\s*session\b/,
-    /\bend (this|the)?\s*session\b/,
-    /\bstop (this|the)?\s*session\b/,
-    /\bfinish (this|the)?\s*session\b/,
-    /\bthat'?s all\b/,
-    /\bwe are done\b/,
-    /\bi am done\b/,
-  ];
-  return patterns.some((pattern) => pattern.test(normalized));
 }
 
 function summarizeMessageTitle(text: string): string {
@@ -393,15 +403,23 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historyError, setHistoryError] = useState<string | null>(null);
   const [selectedHistoryId, setSelectedHistoryId] = useState<string | null>(null);
+  const [showMessages, setShowMessages] = useState(false);
   const [avatarBlinking, setAvatarBlinking] = useState(false);
   const [avatarMouthLevel, setAvatarMouthLevel] = useState<0 | 1 | 2 | 3>(0);
   const [avatarGaze, setAvatarGaze] = useState<"center" | "left" | "right">("center");
   const [avatarHeadMotionClass, setAvatarHeadMotionClass] = useState("rotate-0 translate-y-0");
   const transcriptRef = useRef<string[]>([]);
   const startedAtRef = useRef<number>(0);
+  const activeConnectedAtRef = useRef<number>(0);
   const phaseRef = useRef<SessionPhase>("idle");
   const pendingConnectRef = useRef<PendingConnect | null>(null);
   const negotiationRetriesRef = useRef(0);
+  const loadingPublicRetryRef = useRef(false);
+  const loadingSawNonDisconnectedStatusRef = useRef(false);
+  const loadingFailureHandledRef = useRef(false);
+  const isStartingRef = useRef(false);
+  const startAttemptCounterRef = useRef(0);
+  const activeStartAttemptRef = useRef(0);
   const sessionStartedRef = useRef(false);
   const autoEndingRef = useRef(false);
 
@@ -532,11 +550,34 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
     };
   }, []);
 
+  const handleFallbackStartFailure = useCallback((retryErr: unknown) => {
+    loadingFailureHandledRef.current = true;
+    pendingConnectRef.current = null;
+    negotiationRetriesRef.current = 0;
+    sessionStartedRef.current = false;
+    loadingPublicRetryRef.current = false;
+    setConnectHint(null);
+    setNotice(null);
+    setError(
+      formatVoiceCoachConnectionError(
+        retryErr instanceof Error
+          ? retryErr.message
+          : "Public fallback connection failed",
+        retryErr,
+      ),
+    );
+    phaseRef.current = "idle";
+    setPhase("idle");
+  }, []);
+
   const conversation = useConversation({
     onConnect: () => {
       negotiationRetriesRef.current = 0;
       pendingConnectRef.current = null;
       sessionStartedRef.current = true;
+      loadingFailureHandledRef.current = false;
+      loadingSawNonDisconnectedStatusRef.current = false;
+      activeConnectedAtRef.current = Date.now();
       setConnectHint(null);
       phaseRef.current = "active";
       setPhase("active");
@@ -544,6 +585,11 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
     },
     onDisconnect: () => {
       sessionStartedRef.current = false;
+      if (phaseRef.current === "loading") {
+        // During loading, disconnect events can be transient while handshake settles.
+        // Let startup pipeline / timeout set the final state deterministically.
+        return;
+      }
       setPhase((current) => {
         if (current === "active") {
           phaseRef.current = "idle";
@@ -557,18 +603,6 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
       if (normalized) {
         setMessages((current) => [...current, normalized]);
         transcriptRef.current.push(`[${normalized.role}] ${normalized.text}`);
-        if (
-          normalized.role === "user" &&
-          phaseRef.current === "active" &&
-          !autoEndingRef.current &&
-          isSessionEndIntent(normalized.text)
-        ) {
-          autoEndingRef.current = true;
-          setNotice("Ending session now — saving your task and chat history...");
-          window.setTimeout(() => {
-            void endSession(true);
-          }, 0);
-        }
         return;
       }
 
@@ -585,53 +619,75 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
     onError: (message, context) => {
       console.error("[voice-coach] conversation error:", message, context);
 
+      const pending = pendingConnectRef.current;
       if (
         phaseRef.current === "loading" &&
-        isNegotiationTimeout(message, context) &&
-        negotiationRetriesRef.current < 1 &&
-        pendingConnectRef.current
+        pending?.authMode === "signed" &&
+        pending.agentId &&
+        !loadingPublicRetryRef.current &&
+        isRetryableStartupFailure(message, context)
       ) {
-        negotiationRetriesRef.current += 1;
-        setNotice("Connection timed out — retrying once…");
-        if (sessionStartedRef.current) {
-          try {
-            conversation.endSession();
-          } catch (err) {
-            console.warn("[voice-coach] endSession skipped:", err);
-          } finally {
-            sessionStartedRef.current = false;
-          }
+        loadingPublicRetryRef.current = true;
+        pendingConnectRef.current = {
+          authMode: "public",
+          agentId: pending.agentId,
+          sessionOptions: pending.sessionOptions,
+        };
+        setConnectHint(
+          "Signed handshake failed. Retrying with public agent connection…",
+        );
+        try {
+          void conversation.startSession({
+            agentId: pending.agentId,
+            connectionType: "websocket",
+            ...pending.sessionOptions,
+          });
+        } catch (retryErr) {
+          handleFallbackStartFailure(retryErr);
         }
-        const pending = pendingConnectRef.current;
-
-        window.setTimeout(() => {
-          if (phaseRef.current !== "loading" || !pendingConnectRef.current) {
-            return;
-          }
-
-          if (pending.authMode === "signed" && pending.signedUrl) {
-            void conversation.startSession({
-              signedUrl: pending.signedUrl,
-              ...pending.sessionOptions,
-            });
-          } else if (pending.authMode === "public" && pending.agentId) {
-            void conversation.startSession({
-              agentId: pending.agentId,
-              ...pending.sessionOptions,
-            });
-          }
-        }, 1500);
         return;
       }
 
+      loadingFailureHandledRef.current = true;
       pendingConnectRef.current = null;
       negotiationRetriesRef.current = 0;
+      sessionStartedRef.current = false;
+      loadingPublicRetryRef.current = false;
       setConnectHint(null);
       setError(formatVoiceCoachConnectionError(message, context));
       phaseRef.current = "idle";
       setPhase("idle");
     },
   });
+
+  useEffect(() => {
+    if (phase !== "loading") return;
+
+    const timeoutMs = 25_000;
+    const timer = window.setTimeout(() => {
+      if (phaseRef.current !== "loading") return;
+
+      pendingConnectRef.current = null;
+      negotiationRetriesRef.current = 0;
+      sessionStartedRef.current = false;
+      setConnectHint(null);
+      setNotice(null);
+      setError(
+        formatVoiceCoachConnectionError(
+          "NegotiationError: negotiation timed out /rtc/v1/validate v1 RTC path not found",
+        ),
+      );
+      try {
+        conversation.endSession();
+      } catch (err) {
+        console.warn("[voice-coach] endSession skipped:", err);
+      }
+      phaseRef.current = "idle";
+      setPhase("idle");
+    }, timeoutMs);
+
+    return () => window.clearTimeout(timer);
+  }, [conversation, phase]);
 
   const avatarIsActive = phase === "active" || phase === "ending";
   const avatarIsSpeaking = avatarIsActive && conversation.isSpeaking;
@@ -688,7 +744,14 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
   }, [avatarIsActive, avatarIsSpeaking]);
 
   const safeEndConversation = useCallback(() => {
-    if (!sessionStartedRef.current) return;
+    const shouldAttemptEnd =
+      sessionStartedRef.current ||
+      conversation.status === "connected" ||
+      phaseRef.current === "loading" ||
+      phaseRef.current === "active" ||
+      phaseRef.current === "ending";
+    if (!shouldAttemptEnd) return;
+
     try {
       conversation.endSession();
     } catch (err) {
@@ -697,6 +760,78 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
       sessionStartedRef.current = false;
     }
   }, [conversation]);
+
+  useEffect(() => {
+    if (phase !== "loading" || loadingFailureHandledRef.current) {
+      return;
+    }
+
+    if (conversation.status !== "disconnected") {
+      loadingSawNonDisconnectedStatusRef.current = true;
+      return;
+    }
+
+    const hasStartedNegotiation = loadingSawNonDisconnectedStatusRef.current;
+    const exceededGracePeriod = Date.now() - startedAtRef.current > 4_000;
+    if (!hasStartedNegotiation || !exceededGracePeriod) {
+      return;
+    }
+
+    loadingFailureHandledRef.current = true;
+
+    const pending = pendingConnectRef.current;
+    if (
+      pending?.authMode === "signed" &&
+      pending.agentId &&
+      !loadingPublicRetryRef.current
+    ) {
+      loadingPublicRetryRef.current = true;
+      pendingConnectRef.current = {
+        authMode: "public",
+        agentId: pending.agentId,
+        sessionOptions: pending.sessionOptions,
+      };
+      setConnectHint(
+        "Signed handshake stalled. Retrying with public agent connection…",
+      );
+      void conversation.startSession({
+        agentId: pending.agentId,
+        connectionType: "websocket",
+        ...pending.sessionOptions,
+      });
+      return;
+    }
+
+    pendingConnectRef.current = null;
+    negotiationRetriesRef.current = 0;
+    sessionStartedRef.current = false;
+    loadingPublicRetryRef.current = false;
+    setConnectHint(null);
+    setNotice(null);
+    setError(
+      formatVoiceCoachConnectionError(
+        "NegotiationError: negotiation timed out /rtc/v1/validate v1 RTC path not found",
+      ),
+    );
+    safeEndConversation();
+    phaseRef.current = "idle";
+    setPhase("idle");
+  }, [
+    conversation,
+    conversation.status,
+    handleFallbackStartFailure,
+    phase,
+    safeEndConversation,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      pendingConnectRef.current = null;
+      negotiationRetriesRef.current = 0;
+      autoEndingRef.current = false;
+      safeEndConversation();
+    };
+  }, [safeEndConversation]);
 
   const getConversationId = useCallback((): string | undefined => {
     if (!sessionStartedRef.current) return undefined;
@@ -709,24 +844,39 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
   }, [conversation]);
 
   const startSession = useCallback(async () => {
+    if (isStartingRef.current || phaseRef.current === "loading") {
+      setNotice("A connection attempt is already in progress...");
+      return;
+    }
+
+    isStartingRef.current = true;
+    const startAttemptId = ++startAttemptCounterRef.current;
+    activeStartAttemptRef.current = startAttemptId;
+
     getOrCreateStoredUserName();
+    safeEndConversation();
     setError(null);
     setNotice(null);
     setConnectHint(null);
     negotiationRetriesRef.current = 0;
+    loadingPublicRetryRef.current = false;
+    loadingSawNonDisconnectedStatusRef.current = false;
+    loadingFailureHandledRef.current = false;
     pendingConnectRef.current = null;
     sessionStartedRef.current = false;
+    activeConnectedAtRef.current = 0;
     autoEndingRef.current = false;
     phaseRef.current = "loading";
     setPhase("loading");
     setTask(null);
     setSummary(null);
     setAutoEndedByVoice(false);
+    setShowMessages(false);
     setMessages([]);
     transcriptRef.current = [];
 
     try {
-      await navigator.mediaDevices.getUserMedia({
+      const permissionStream = await navigator.mediaDevices.getUserMedia({
         audio: {
           echoCancellation: true,
           noiseSuppression: true,
@@ -734,6 +884,7 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
           channelCount: 1,
         },
       });
+      permissionStream.getTracks().forEach((track) => track.stop());
 
       const res = await fetch(
         `/api/voice-coach/signed-url?mode=${encodeURIComponent(mode)}`,
@@ -752,6 +903,7 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
       if (!res.ok) {
         throw new Error(data.error ?? "Failed to start session");
       }
+      if (activeStartAttemptRef.current !== startAttemptId) return;
 
       if (!data.memory) {
         throw new Error("Invalid session response from server");
@@ -767,12 +919,13 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
           "Connecting via public agent — ensure your ElevenLabs agent is Public under Security.",
         );
       } else if (data.authMode === "signed") {
-        setConnectHint("Connecting securely…");
+        setConnectHint("Connecting via websocket…");
       }
 
       startedAtRef.current = Date.now();
 
       const sessionOptions = {
+        serverLocation: "in-residency" as const,
         dynamicVariables: {
           mode,
           memory: data.memory,
@@ -784,6 +937,7 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
         pending = {
           authMode: "signed",
           signedUrl: data.signedUrl,
+          agentId: data.agentId,
           sessionOptions,
         };
       } else if (data.authMode === "public" && data.agentId) {
@@ -803,18 +957,23 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
       if (pending.authMode === "signed" && pending.signedUrl) {
         await conversation.startSession({
           signedUrl: pending.signedUrl,
+          connectionType: "websocket",
           ...pending.sessionOptions,
         });
       } else if (pending.authMode === "public" && pending.agentId) {
+        loadingPublicRetryRef.current = true;
         await conversation.startSession({
           agentId: pending.agentId,
+          connectionType: "websocket",
           ...pending.sessionOptions,
         });
       }
     } catch (err) {
+      if (activeStartAttemptRef.current !== startAttemptId) return;
       console.error("[voice-coach] start failed:", err);
       pendingConnectRef.current = null;
       sessionStartedRef.current = false;
+      loadingPublicRetryRef.current = false;
       safeEndConversation();
       setConnectHint(null);
       setError(
@@ -825,6 +984,10 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
       );
       phaseRef.current = "idle";
       setPhase("idle");
+    } finally {
+      if (activeStartAttemptRef.current === startAttemptId) {
+        isStartingRef.current = false;
+      }
     }
   }, [conversation, mode, safeEndConversation]);
 
@@ -839,6 +1002,7 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
 
     pendingConnectRef.current = null;
     negotiationRetriesRef.current = 0;
+    loadingPublicRetryRef.current = false;
     setConnectHint(null);
     setAutoEndedByVoice(triggeredByVoiceIntent);
     autoEndingRef.current = true;
@@ -1161,9 +1325,71 @@ function VoiceCoachSessionInner({ mode }: VoiceCoachSessionProps) {
                   {phase === "ending" ? "Saving session…" : "End session"}
                 </button>
               )}
+              <button
+                type="button"
+                onClick={() => setShowMessages(true)}
+                className="inline-flex items-center gap-2 rounded-xl border border-white/10 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <MessageSquareText className="h-4 w-4" />
+                View Messages {messages.length > 0 ? `(${messages.length})` : ""}
+              </button>
             </div>
           </div>
         </div>
+        {showMessages && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 p-4 backdrop-blur-sm">
+            <div className="max-h-[80vh] w-full max-w-3xl overflow-hidden rounded-2xl border border-white/10 bg-[#111114] shadow-[0_0_40px_rgba(0,0,0,0.35)]">
+              <div className="flex items-center justify-between border-b border-white/10 px-5 py-4">
+                <h3 className="text-lg font-semibold text-white">Live Messages</h3>
+                <button
+                  type="button"
+                  onClick={() => setShowMessages(false)}
+                  className="rounded-md border border-white/10 px-3 py-1.5 text-xs font-medium text-white hover:bg-white/10"
+                >
+                  Close
+                </button>
+              </div>
+              <div className="max-h-[65vh] space-y-3 overflow-y-auto px-5 py-4">
+                {messages.length === 0 ? (
+                  <p className="text-sm text-[#9ca3af]">No messages yet for this session.</p>
+                ) : (
+                  messages.map((message, index) => (
+                    <div
+                      key={`${message.timestamp}-${index}`}
+                      className={`rounded-xl border px-4 py-3 ${
+                        message.role === "agent"
+                          ? "border-[#8b5cf6]/25 bg-[#8b5cf6]/10"
+                          : "border-white/10 bg-[#0b0b0d]"
+                      }`}
+                    >
+                      <div className="flex items-start gap-3">
+                        <div
+                          className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full border ${
+                            message.role === "agent"
+                              ? "border-[#8b5cf6]/45 bg-[#8b5cf6]/20 text-[#d8b4fe]"
+                              : "border-white/15 bg-white/10 text-white"
+                          }`}
+                        >
+                          {message.role === "agent" ? (
+                            <CoachFace avatar={coachAvatar} speaking={false} size="small" />
+                          ) : (
+                            <UserRound className="h-4 w-4" />
+                          )}
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className="text-xs uppercase tracking-wide text-[#8b5cf6]">
+                            {message.role === "agent" ? coachAvatar.name : "You"}
+                          </p>
+                          <p className="mt-1 text-sm text-white">{message.text}</p>
+                        </div>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          </div>
+        )}
         <HistoryContent
           selectedHistoryItem={selectedHistoryItem}
           selectedHistoryMessages={selectedHistoryMessages}

--- a/lib/elevenlabs-config.ts
+++ b/lib/elevenlabs-config.ts
@@ -22,13 +22,19 @@ export function getElevenLabsAgentId(): string | undefined {
 
 import { parseElevenLabsErrorBody } from "@/lib/elevenlabs-errors";
 
+type ElevenLabsAuthResponse =
+  | { ok: true; value: string }
+  | {
+      ok: false;
+      status: number;
+      detail: string;
+      parsed: ReturnType<typeof parseElevenLabsErrorBody>;
+    };
+
 export async function fetchElevenLabsSignedUrl(
   agentId: string,
   apiKey: string,
-): Promise<
-  | { ok: true; signedUrl: string }
-  | { ok: false; status: number; detail: string; parsed: ReturnType<typeof parseElevenLabsErrorBody> }
-> {
+): Promise<ElevenLabsAuthResponse> {
   const response = await fetch(
     `https://api.elevenlabs.io/v1/convai/conversation/get-signed-url?agent_id=${encodeURIComponent(agentId)}`,
     {
@@ -59,5 +65,42 @@ export async function fetchElevenLabsSignedUrl(
     };
   }
 
-  return { ok: true, signedUrl: data.signed_url };
+  return { ok: true, value: data.signed_url };
+}
+
+export async function fetchElevenLabsConversationToken(
+  agentId: string,
+  apiKey: string,
+): Promise<ElevenLabsAuthResponse> {
+  const response = await fetch(
+    `https://api.elevenlabs.io/v1/convai/conversation/token?agent_id=${encodeURIComponent(agentId)}`,
+    {
+      headers: {
+        "xi-api-key": apiKey,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    const detail = await response.text();
+    return {
+      ok: false,
+      status: response.status,
+      detail,
+      parsed: parseElevenLabsErrorBody(detail),
+    };
+  }
+
+  const data = (await response.json()) as { token: string };
+  if (!data?.token) {
+    const detail = "Missing token in ElevenLabs response";
+    return {
+      ok: false,
+      status: response.status || 502,
+      detail,
+      parsed: parseElevenLabsErrorBody(detail),
+    };
+  }
+
+  return { ok: true, value: data.token };
 }

--- a/lib/voice-coach-connection-errors.ts
+++ b/lib/voice-coach-connection-errors.ts
@@ -21,12 +21,13 @@ export function formatVoiceCoachConnectionError(
 
   if (isNegotiationTimeout(message, err)) {
     return (
-      "Voice connection timed out (WebRTC could not connect in time).\n\n" +
+      "Voice connection timed out (transport handshake could not complete in time).\n\n" +
       "Try these steps:\n" +
       "1. In ElevenLabs → your agent → Security, enable Public (required if you see a convai_write warning).\n" +
       "2. Confirm ELEVENLABS_VOICE_COACH_AGENT_ID in .env.local matches that agent.\n" +
       "3. Use Chrome or Edge, allow the microphone, and try another network (hotspot) if on school or VPN Wi‑Fi.\n" +
-      "4. Restart npm run dev after changing .env.local."
+      "4. If you see repeated LiveKit reconnect/disconnect loops, disable VPN/proxy/firewall filtering and allow UDP/realtime traffic.\n" +
+      "5. Restart npm run dev after changing .env.local."
     );
   }
 
@@ -50,6 +51,39 @@ export function formatVoiceCoachConnectionError(
   if (combined.includes("network") || combined.includes("failed to fetch")) {
     return (
       "Network error while connecting. Check your internet connection and try again."
+    );
+  }
+
+  if (
+    combined.includes("closed before session start") ||
+    combined.includes("already in closing or closed state")
+  ) {
+    return (
+      "Voice handshake closed early.\n\n" +
+      "Try these steps:\n" +
+      "1. Set your ElevenLabs agent Security to Public.\n" +
+      "2. Verify ELEVENLABS_VOICE_COACH_AGENT_ID matches that same agent.\n" +
+      "3. Disable VPN/firewall filtering and retry on another network if possible.\n" +
+      "4. Restart npm run dev and reconnect."
+    );
+  }
+
+  if (combined.includes("did not complete") || combined.includes("websocket")) {
+    return (
+      "Voice websocket did not complete handshake.\n\n" +
+      "Ensure your browser can reach wss://api.elevenlabs.io and your agent access settings allow this app."
+    );
+  }
+
+  if (
+    combined.includes("v1 rtc path not found") ||
+    combined.includes("/rtc/v1/validate") ||
+    combined.includes("unknown datachannel error")
+  ) {
+    return (
+      "Voice transport handshake is failing between browser and ElevenLabs LiveKit.\n\n" +
+      "This is usually a network path issue (VPN/proxy/firewall/WebRTC blocking), not your end-session phrase logic.\n" +
+      "Try a different network (mobile hotspot), disable VPN/proxy, and retry."
     );
   }
 


### PR DESCRIPTION
This pull request enhances the Voice Coach session history by surfacing the most recent action point task in both the API and UI, and improves the user experience with new visual cues and state handling. The changes span both the backend API and the frontend interface, ensuring that users can see the latest task associated with each session and receive clearer feedback during and after sessions.

**Backend/API Improvements:**

* The `SessionRow` and `VoiceCoachHistoryItem` interfaces in `route.ts` now include an `action_points` array and a `task` field, respectively, allowing the API to expose the most recent task for each session. [[1]](diffhunk://#diff-95b58c72befd2c8bb93d098541fbe923ce3fc9da0fd94002c487768247bdc0f5R9) [[2]](diffhunk://#diff-95b58c72befd2c8bb93d098541fbe923ce3fc9da0fd94002c487768247bdc0f5R20)
* The Supabase query in the API now fetches the `action_points` (with `task` and `created_at`) for each session, making task data available to the frontend.
* The `mapHistoryItem` function extracts the latest task from the session’s `action_points` and includes it in the returned history item.

**Frontend/UI Enhancements:**

* The session UI now displays a "Task" chip for the selected history item if a task is present, giving users quick visibility into the session's focus.
* The history sidebar features a "New Chat" badge and improved selection styling, making navigation clearer and more visually appealing. [[1]](diffhunk://#diff-89378be4b8d3e531443c96581b3313d88a877c2406aa164525d292678c42679aL1183-R1199) [[2]](diffhunk://#diff-89378be4b8d3e531443c96581b3313d88a877c2406aa164525d292678c42679aL1211-R1234)

**Session State & Experience:**

* Introduced `autoEndedByVoice` state to track and display when a session is auto-ended by a voice command, including a new visual indicator in the session complete screen. [[1]](diffhunk://#diff-89378be4b8d3e531443c96581b3313d88a877c2406aa164525d292678c42679aR390) [[2]](diffhunk://#diff-89378be4b8d3e531443c96581b3313d88a877c2406aa164525d292678c42679aR843) [[3]](diffhunk://#diff-89378be4b8d3e531443c96581b3313d88a877c2406aa164525d292678c42679aR936-R940) [[4]](diffhunk://#diff-89378be4b8d3e531443c96581b3313d88a877c2406aa164525d292678c42679aR724) [[5]](diffhunk://#diff-89378be4b8d3e531443c96581b3313d88a877c2406aa164525d292678c42679aR952)
* Ensured that the `task` and `autoEndedByVoice` states are reset appropriately when starting or ending sessions, preventing stale state from affecting new sessions. [[1]](diffhunk://#diff-89378be4b8d3e531443c96581b3313d88a877c2406aa164525d292678c42679aR472) [[2]](diffhunk://#diff-89378be4b8d3e531443c96581b3313d88a877c2406aa164525d292678c42679aR724) [[3]](diffhunk://#diff-89378be4b8d3e531443c96581b3313d88a877c2406aa164525d292678c42679aR952)

These changes collectively improve the clarity, usefulness, and polish of the Voice Coach session history and user experience.- Introduced a new `action_points` field in session history to track tasks associated with each session.
- Updated the session mapping to include the latest task in the history items.
- Added state management for auto-ending sessions triggered by voice commands, with a visual indication in the UI.
- Enhanced the history sidebar to display task information for selected history items, improving user engagement and clarity.