### PR TITLE
fix(supabase): add speech-eval columns migration and env key guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ ELEVENLABS_VOICE_COACH_AGENT_ID=
 OPENAI_API_KEY=
 GROQ_API_KEY=
 
-# Sessions, coach memory, dashboard homework (run supabase/migrations/*.sql)
+# Sessions, coach memory, dashboard homework (run supabase/migrations/*.sql in order)
+# Anon key must be a JWT (eyJ...), from Supabase → Project Settings → API → anon public
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=

--- a/docs/supabase-persistence.md
+++ b/docs/supabase-persistence.md
@@ -12,6 +12,12 @@
 
 Apply migrations in `supabase/migrations/` on your Supabase project (Dashboard SQL or CLI), in filename order, before expecting voice history to persist.
 
+**Deploy checklist (shared Supabase):**
+
+1. Run every file in `supabase/migrations/` in order (or `supabase/all_migrations.sql` once on a fresh project).
+2. Set `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` on the host (Vercel/etc.) — anon key must be the JWT (`eyJ...`), not `sb_publishable_...`.
+3. After deploy, confirm a speech eval and voice coach end-session create rows in `sessions` for the signed-in user.
+
 ## Product → `sessions.feature`
 
 | Product | Route | `feature` | Other tables |

--- a/lib/supabase/env.ts
+++ b/lib/supabase/env.ts
@@ -14,5 +14,11 @@ export function getSupabasePublicEnv(): { url: string; anonKey: string } {
     )
   }
 
+  if (anonKey.startsWith('sb_publishable_')) {
+    throw new Error(
+      'Invalid NEXT_PUBLIC_SUPABASE_ANON_KEY: use the anon public key from Supabase Dashboard (JWT starting with eyJ), not a publishable key.'
+    )
+  }
+
   return { url, anonKey }
 }

--- a/supabase/all_migrations.sql
+++ b/supabase/all_migrations.sql
@@ -239,3 +239,21 @@ GRANT SELECT ON session_messages TO anon;
 
 -- Refresh PostgREST schema cache (fixes "relationship ... session_messages" errors)
 NOTIFY pgrst, 'reload schema';
+
+-- -----------------------------------------------------------------------------
+-- 5. 20260517200000_speech_eval_columns_and_grants.sql
+-- (legacy DBs that created sessions without feedback columns)
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE sessions
+  ADD COLUMN IF NOT EXISTS counter_feedback text,
+  ADD COLUMN IF NOT EXISTS grammarian_feedback text,
+  ADD COLUMN IF NOT EXISTS evaluator_feedback text,
+  ADD COLUMN IF NOT EXISTS evaluator_score integer,
+  ADD COLUMN IF NOT EXISTS filler_word_count integer;
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_coach_memory_user_id_key
+  ON user_coach_memory (user_id)
+  WHERE user_id IS NOT NULL;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260517200000_speech_eval_columns_and_grants.sql
+++ b/supabase/migrations/20260517200000_speech_eval_columns_and_grants.sql
@@ -1,0 +1,31 @@
+-- Speech eval feedback columns (legacy DBs may only have user_id + scores).
+-- Grants for session_messages and coach memory upsert — safe to re-run.
+
+ALTER TABLE sessions
+  ADD COLUMN IF NOT EXISTS counter_feedback text,
+  ADD COLUMN IF NOT EXISTS grammarian_feedback text,
+  ADD COLUMN IF NOT EXISTS evaluator_feedback text,
+  ADD COLUMN IF NOT EXISTS evaluator_score integer,
+  ADD COLUMN IF NOT EXISTS filler_word_count integer;
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_coach_memory_user_id_key
+  ON user_coach_memory (user_id)
+  WHERE user_id IS NOT NULL;
+
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO authenticated;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO anon;
+
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO authenticated;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON session_messages TO authenticated;
+GRANT SELECT ON session_messages TO anon;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
This pull request improves the Supabase integration by clarifying deployment instructions, enforcing correct environment variable usage, and updating the database schema and permissions for speech evaluation features. The changes ensure that deployments use the correct anon key, guide users through migration steps, and add necessary columns and grants for legacy databases.

**Deployment and Environment Configuration:**
- Updated `.env.example` to clarify that the anon key must be a JWT (starting with `eyJ...`) and provided guidance on where to find it in the Supabase dashboard.
- Improved documentation in `docs/supabase-persistence.md` with a deploy checklist, emphasizing running migrations in order and using the correct anon key.
- Added a runtime check in `lib/supabase/env.ts` to throw an error if the Supabase anon key is a publishable key (`sb_publishable_...`) instead of a JWT, preventing misconfiguration.

**Database Schema and Permissions:**
- Added a new migration file (`supabase/migrations/20260517200000_speech_eval_columns_and_grants.sql`) to add speech evaluation feedback columns to the `sessions` table, create a unique index on `user_coach_memory.user_id`, and update grants for legacy databases.
- Updated `supabase/all_migrations.sql` to include the new migration for legacy database compatibility, ensuring all expected columns and indexes exist.