### PR TITLE
fix(auth): route try flow to dashboard after login

### DIFF
--- a/components/landing/CtaSection.tsx
+++ b/components/landing/CtaSection.tsx
@@ -21,7 +21,7 @@ export function CtaSection() {
             prepared, confident, and ready.
           </p>
           <Link
-            href={buildLoginHref('/voice-coach', 'Interview')}
+            href={buildLoginHref('/dashboard')}
             className="mt-10 inline-block rounded-xl bg-[#8b5cf6] px-10 py-4 text-lg font-semibold text-white transition-colors hover:bg-[#7c3aed]"
           >
             Start Practicing Free

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -48,7 +48,7 @@ export function HeroSection() {
 
         <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
           <Link
-            href={buildLoginHref('/voice-coach', 'Interview')}
+            href={buildLoginHref('/dashboard')}
             className="w-full rounded-xl bg-[#8b5cf6] px-8 py-3.5 text-center text-base font-semibold text-white transition-colors hover:bg-[#7c3aed] sm:w-auto"
           >
             Start Practicing Free

--- a/components/landing/Navbar.tsx
+++ b/components/landing/Navbar.tsx
@@ -40,7 +40,7 @@ export function Navbar() {
         </nav>
 
         <Link
-          href={buildLoginHref('/voice-coach', 'Interview')}
+          href={buildLoginHref('/dashboard')}
           className="shrink-0 rounded-lg bg-[#8b5cf6] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#7c3aed]"
         >
           Start Practicing Free


### PR DESCRIPTION
Update landing "Start Practicing Free" CTAs to use the dashboard destination so post-login redirects do not bypass the main app entry point.